### PR TITLE
Fix for Firefox

### DIFF
--- a/src/light-popup-card.ts
+++ b/src/light-popup-card.ts
@@ -462,6 +462,27 @@ class LightPopupCard extends LitElement {
             position: relative;
             top: calc((var(--slider-width) - 80px) / 2);
         }
+        .range-holder input[type="range"]::-moz-thumb-track {
+            height: var(--slider-width);
+            background-color: var(--slider-track-color);
+            margin-top: -1px;
+            transition: box-shadow 0.2s ease-in-out;
+        }
+        .range-holder input[type="range"]::-moz-range-thumb {
+            width: 5px;
+            border-right:12px solid var(--slider-color);
+            border-left:12px solid var(--slider-color);
+            border-top:20px solid var(--slider-color);
+            border-bottom:20px solid var(--slider-color);
+            height: calc(var(--slider-width)*.4);
+            cursor: ew-resize;
+            background: #fff;
+            box-shadow: -350px 0 0 350px var(--slider-color), inset 0 0 0 80px var(--slider-thumb-color);
+            border-radius: 0;
+            transition: box-shadow 0.2s ease-in-out;
+            position: relative;
+            top: calc((var(--slider-width) - 80px) / 2);
+        }
         .switch-holder {
             height: var(--switch-height);
             width: var(--switch-width);


### PR DESCRIPTION
Firefox did not work as the the --moz selectors were not used. Adding the selectors helps, but there is enough other bits different between Firefox and Chrome that separate classes are required. New CSS tested on both Firefox and Chrome. Combining common styles would seem to be a better approach (less CSS code) however there's neither browser would recognize the second of the two combined styles. Changing the order of the `,` selector would fix one browser but break the other (and vice-versa).

See https://community.home-assistant.io/t/card-tools-popup-homekit-style-card/119722/121?u=gwww for before picture.

I will submit a separate PR for the `switch-holder` css.