### PR TITLE
add support for custom states

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ resources:
 
 ### Main Options
 
-| Name | Type | Default | Supported options | Description |
+| Name | Type | Required | Default | Description |
 | -------------- | ----------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity` | string | **Required** | `light.kitchen` | Entity of the light |
+| `entity` | string | **Required** |  | Entity of the light |
 | `icon` | string | optional | `mdi:lightbulb` | It will use customize entity icon or from the config as a fallback it used lightbulb icon |
 | `fullscreen` | boolean | optional | true | If false it will remove the pop-up wrapper which makes it fullscreen |
 | `supportedFeaturesTreshold` | number | optional | 9 | When the supported features of the light is larger than the treshold than the brightness slider is rendered if it is equal or lower a switch is rendered |
+| `offStates` | array | optional | - "off" | Array of states that will make the switch appear to be off |
+| `onStates` | array | optional | - "on" | Array of states that will make the switch appear to be on |
 | `actions` | object | optional | `actions:`  | define actions that you can activate from the pop-up. |
 | `actionSize` | string | optional | `50px`  | Set the size of the action buttons default `50px` |
 | `actionsInARow` | number | optional | 3 | number of actions that will be placed in a row under the brightness slider |

--- a/src/light-popup-card.ts
+++ b/src/light-popup-card.ts
@@ -38,6 +38,8 @@ class LightPopupCard extends LitElement {
     var icon = this.config.icon ? this.config.icon : stateObj.attributes.icon ? stateObj.attributes.icon: 'mdi:lightbulb';
     var borderRadius = this.config.borderRadius ? this.config.borderRadius : '12px';  
     var supportedFeaturesTreshold = this.config.supportedFeaturesTreshold ? this.config.supportedFeaturesTreshold : 9;
+    var onStates = this.config.onStates ? this.config.onStates : ['on'];
+    var offStates = this.config.offStates ? this.config.offStates : ['off'];
     //Scenes
     var actionSize = "actionSize" in this.config ? this.config.actionSize : "50px";
     var actions = this.config.actions;
@@ -55,16 +57,11 @@ class LightPopupCard extends LitElement {
     }
 
     var switchValue = 0;
-    switch(stateObj.state) {
-        case 'on':
-            switchValue = 1;
-            break;
-        case 'off':
-            switchValue = 0;
-            break;
-        default:
-            switchValue = 0;
+
+    if (onStates.includes(stateObj.state)) {
+      switchValue = 1;
     }
+
     var fullscreen = "fullscreen" in this.config ? this.config.fullscreen : true;
     var brightnessWidth = this.config.brightnessWidth ? this.config.brightnessWidth : "150px";
     var brightnessHeight = this.config.brightnessHeight ? this.config.brightnessHeight : "400px";
@@ -101,12 +98,12 @@ class LightPopupCard extends LitElement {
       <div class="${fullscreen === true ? 'popup-wrapper':''}">
             <div id="popup" class="popup-inner" @click="${e => this._close(e)}">
                 <div class="icon${fullscreen === true ? ' fullscreen':''}">
-                    <ha-icon style="${stateObj.state === "on" ? 'color:'+color+';' : ''}" icon="${icon}" />
+                    <ha-icon style="${onStates.includes(stateObj.state) ? 'color:'+color+';' : ''}" icon="${icon}" />
                 </div>
                 ${ stateObj.attributes.supported_features > supportedFeaturesTreshold ? html`
-                    <h4 id="brightnessValue" class="${stateObj.state === "off" ? '' : 'brightness'}" data-value="${this.currentBrightness}%">${stateObj.state === "off" ? computeStateDisplay(this.hass.localize, stateObj, this.hass.language) : ''}</h4>
+                    <h4 id="brightnessValue" class="${offStates.includes(stateObj.state) ? '' : 'brightness'}" data-value="${this.currentBrightness}%">${offStates.includes(stateObj.state) ? computeStateDisplay(this.hass.localize, stateObj, this.hass.language) : ''}</h4>
                     <div class="range-holder" style="--slider-height: ${brightnessHeight};--slider-width: ${brightnessWidth};">
-                        <input type="range" style="--slider-width: ${brightnessWidth};--slider-height: ${brightnessHeight}; --slider-border-radius: ${borderRadius};${sliderColoredByLight ? '--slider-color:'+color+';':'--slider-color:'+sliderColor+';'}--slider-thumb-color:${sliderThumbColor};--slider-track-color:${sliderTrackColor};" .value="${stateObj.state === "off" ? 0 : Math.round(stateObj.attributes.brightness/2.55)}" @input=${e => this._previewBrightness(e.target.value)} @change=${e => this._setBrightness(stateObj, e.target.value)}>
+                        <input type="range" style="--slider-width: ${brightnessWidth};--slider-height: ${brightnessHeight}; --slider-border-radius: ${borderRadius};${sliderColoredByLight ? '--slider-color:'+color+';':'--slider-color:'+sliderColor+';'}--slider-thumb-color:${sliderThumbColor};--slider-track-color:${sliderTrackColor};" .value="${offStates.includes(stateObj.state) ? 0 : Math.round(stateObj.attributes.brightness/2.55)}" @input=${e => this._previewBrightness(e.target.value)} @change=${e => this._setBrightness(stateObj, e.target.value)}>
                     </div>
                 ` : html`
                     <h4>${computeStateDisplay(this.hass.localize, stateObj, this.hass.language)}</h4>


### PR DESCRIPTION
This adds onStates and offStates to support states besides on/off.

Example:

```yaml
            popup:
              settings: true
              type: 'custom:light-popup-card'
              onStates:
                - open
              offStates:
                - closed
```