### PR TITLE
Update light-popup-card.ts

### DIFF
--- a/src/light-popup-card.ts
+++ b/src/light-popup-card.ts
@@ -635,7 +635,7 @@ class LightPopupCard extends LitElement {
         -o-transform: rotate(270deg);
         -ms-transform: rotate(270deg);
         transform: rotate(270deg);
-        overflow: hidden;
+        overflow: auto;
         height: var(--slider-width);
         -webkit-appearance: none;
         background-color: var(--slider-track-color);
@@ -707,7 +707,7 @@ class LightPopupCard extends LitElement {
         -o-transform: rotate(270deg);
         -ms-transform: rotate(270deg);
         transform: rotate(270deg);
-        overflow: hidden;
+        overflow: auto;
         height: calc(var(--switch-width) - 20px);
         -webkit-appearance: none;
         background-color: var(--switch-track-color);


### PR DESCRIPTION
Fix issue with overflow:hidden not working on iOS versions prior to iOS 13

Prior
![image](https://user-images.githubusercontent.com/2084614/169695229-d20c120a-f7af-46b0-b261-3731b116269d.png)

After
![image](https://user-images.githubusercontent.com/2084614/169695206-aa8255d7-c3d7-4585-80ce-083161d4b94d.png)
